### PR TITLE
make deps less strict to work across trusty -> xenial

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
-jujubundlelib==0.4.1
-requests==2.6.0
+jujubundlelib>=0.4.1
+requests>=2.2.1

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     package_dir={'theblues': 'theblues'},
     include_package_data=True,
     install_requires=[
-        'requests==2.6.0',
+        'requests>=2.1.1',
+        'jujubundlelib>=0.4.1',
     ],
     tests_requires=[
         'httmock==1.2.3',


### PR DESCRIPTION
This fixes the following traceback which will happen to any user or package using theblues.

```
Traceback (most recent call last):
  File "/usr/bin/charm-version", line 5, in <module>
    from pkg_resources import load_entry_point
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3141, in <module>
    @_call_aside
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3127, in _call_aside
    f(*args, **kwargs)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 3154, in _initialize_master_working_set
    working_set = WorkingSet._build_master()
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 642, in _build_master
    return cls._build_from_requirements(__requires__)
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 655, in _build_from_requirements
    dists = ws.resolve(reqs, Environment())
  File "/usr/lib/python2.7/dist-packages/pkg_resources/__init__.py", line 833, in resolve
    raise VersionConflict(dist, req).with_context(dependent_req)
pkg_resources.ContextualVersionConflict: (requests 2.2.1 (/usr/lib/python2.7/dist-packages), Requirement.parse('requests==2.6.0'), set(['theblues']))
```

fixes #21 
