### PR TITLE
Include owner in API call

### DIFF
--- a/theblues/charmstore.py
+++ b/theblues/charmstore.py
@@ -120,6 +120,7 @@ class CharmStore(object):
             'charm-metadata',
             'common-info',
             'extra-info',
+            'owner',
             'revision-info',
             'published',
             'stats',


### PR DESCRIPTION
Add `owner` to the list of includes when calling API. Leaving `extra-info` until the storefront stops using it.
