### PR TITLE
Provide default charm store URL

### DIFF
--- a/theblues/charmstore.py
+++ b/theblues/charmstore.py
@@ -15,17 +15,18 @@ from .errors import (
     EntityNotFound,
     ServerError,
     )
-from theblues.utils import DEFAULT_TIMEOUT
+from theblues.utils import DEFAULT_TIMEOUT, API_URL
 
 
 class CharmStore(object):
     """A connection to the charmstore."""
 
-    def __init__(self, url, macaroons=None, timeout=DEFAULT_TIMEOUT,
-                 verify=True):
+    def __init__(self, url=API_URL, macaroons=None,
+                 timeout=DEFAULT_TIMEOUT, verify=True):
         """Initializer.
 
-        @param url The url to the charmstore API.
+        @param url The base url to the charmstore API.  Defaults
+            to `https://api.jujucharms.com/`.
         @param macaroons The optional discharged macaroon allowing access to
             authenticated queries against the charmstore.
         @param timeout How long to wait in seconds before timing out a request;

--- a/theblues/utils.py
+++ b/theblues/utils.py
@@ -15,6 +15,7 @@ from theblues.errors import (
 )
 
 
+API_URL = 'https://api.jujucharms.com/v5'
 DEFAULT_TIMEOUT = 3.05
 _error_message = 'Error during request: {url} message: {message}'
 


### PR DESCRIPTION
Supports overriding the default URL for backwards compatibility.

Fixes #45
