### PR TITLE
use /charmstore/v5, not /v5

### DIFF
--- a/theblues/utils.py
+++ b/theblues/utils.py
@@ -15,7 +15,7 @@ from theblues.errors import (
 )
 
 
-API_URL = 'https://api.jujucharms.com/v5'
+API_URL = 'https://api.jujucharms.com/charmstore/v5'
 DEFAULT_TIMEOUT = 3.05
 _error_message = 'Error during request: {url} message: {message}'
 


### PR DESCRIPTION
AFAIK we make no guarantees that api.jujucharms.com/ will be the charmstore api. Instead, we have /charmstore, /identity, /bundleservice, a few others. It is coincidence that our current apache config default to charmstore at the root. We should not rely on it.