### PR TITLE
Make session persistant per CS object

### DIFF
--- a/theblues/charmstore.py
+++ b/theblues/charmstore.py
@@ -57,6 +57,7 @@ class CharmStore(object):
         super(CharmStore, self).__init__()
         self.url = url
         self.verify = verify
+        self.session = requests.Session()
         self.timeout = timeout
         self.cookies = cookies
         if client is None:
@@ -71,7 +72,7 @@ class CharmStore(object):
             (e.g. https://api.jujucharms.com/charmstore/v4/macaroon)
         """
         try:
-            response = requests.get(url, verify=self.verify,
+            response = self.session.get(url, verify=self.verify,
                                     cookies=self.cookies, timeout=self.timeout,
                                     auth=self._client.auth())
             response.raise_for_status()


### PR DESCRIPTION
# Summary

- Make session persistant.
- Since only one API is used in the CS object we can make use of connection pooling integrated in requests.Session, this would save the https negociation between requests
- Havin a session per object could allow us to configure it in the future (adding specific headers/timeouts/etc.)
- Use case: on jaas.ai we would like to have a persistant session to be able to make requests analysis (duration, etc.). 